### PR TITLE
Add jwt authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ out/
 .DS_[Ss]tore
 *.log
 .env
+/env
 
 # Python files
 __pycache__

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,8 @@ gunicorn = "*"
 python-dotenv = "*"
 flasgger = "*"
 flask-cors = "*"
+werkzeug = "*"
+flask-jwt-extended = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4387467ff3cc27bc1bcceed144ed2ce38e73a2898439902e9c9c659d4cd53c6e"
+            "sha256": "f442e27f808c71a340bc0649b6c13080279c1500b16e2d63edefff3b8fe58722"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -55,6 +55,14 @@
             ],
             "index": "pypi",
             "version": "==3.0.10"
+        },
+        "flask-jwt-extended": {
+            "hashes": [
+                "sha256:ad6977b07c54e51c13b5981afc246868b9901a46715d9b9827898bfd916aae88",
+                "sha256:c82c9e505bc96f4a5186de31c05262dbcde6fa10581e9aa46df8f99ca04be2c3"
+            ],
+            "index": "pypi",
+            "version": "==4.3.1"
         },
         "flask-sqlalchemy": {
             "hashes": [
@@ -146,19 +154,19 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:827a0e32839ab1600d4eb1c4c33ec5a8edfbc5cb42dafa13b81f182f97784b45",
-                "sha256:8569982d3f0889eed11dd620c706d39b60c36d6d25843961f33f77fb6bc6b20c"
+                "sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8",
+                "sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.0.2"
+            "version": "==3.0.3"
         },
         "jsonschema": {
             "hashes": [
-                "sha256:2b563117f3659a7f433dffe1371c88f52115b79133493f376f15724b9caa7efa",
-                "sha256:e2d3601321ac74d38214e2853300ae740cd07e53d919a15862b8c71f9d840574"
+                "sha256:2a0f162822a64d95287990481b45d82f096e99721c86534f48201b64ebca6e8c",
+                "sha256:390713469ae64b8a58698bb3cbc3859abe6925b565a973f87323ef21b09a27a8"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==4.2.0"
+            "version": "==4.2.1"
         },
         "markupsafe": {
             "hashes": [
@@ -244,62 +252,70 @@
         },
         "psycopg2": {
             "hashes": [
-                "sha256:079d97fc22de90da1d370c90583659a9f9a6ee4007355f5825e5f1c70dffc1fa",
-                "sha256:2087013c159a73e09713294a44d0c8008204d06326006b7f652bef5ace66eebb",
-                "sha256:25615574419dd9bda6fdfdcd58afb22e721f5b807cb3d5e62f488c8acf8cb754",
-                "sha256:2c992196719fadda59f72d44603ee1a2fdcc67de097eea38d41c7ad9ad246e62",
-                "sha256:7640e1e4d72444ef012e275e7b53204d7fab341fb22bc76057ede22fe6860b25",
-                "sha256:7f91312f065df517187134cce8e395ab37f5b601a42446bdc0f0d51773621854",
-                "sha256:830c8e8dddab6b6716a4bf73a09910c7954a92f40cf1d1e702fb93c8a919cc56",
-                "sha256:89409d369f4882c47f7ea20c42c5046879ce22c1e4ea20ef3b00a4dfc0a7f188",
-                "sha256:bf35a25f1aaa8a3781195595577fcbb59934856ee46b4f252f56ad12b8043bcf",
-                "sha256:de5303a6f1d0a7a34b9d40e4d3bef684ccc44a49bbe3eb85e3c0bffb4a131b7c",
-                "sha256:e5a8ed9dbfca8dc162c4ada5ab017e10d5a66c542b4c73569f103fa5f342f498"
+                "sha256:26322c3f114de1f60c1b0febf8fdd595c221b4f624524178f515d07350a71bd1",
+                "sha256:6796ac614412ce374587147150e56d03b7845c9e031b88aacdcadc880e81bb38",
+                "sha256:77b9105ef37bc005b8ffbcb1ed6d8685bb0e8ce84773738aa56421a007ec5a7a",
+                "sha256:77d09a79f9739b97099d2952bbbf18eaa4eaf825362387acbb9552ec1b3fa228",
+                "sha256:91c7fd0fe9e6c118e8ff5b665bc3445781d3615fa78e131d0b4f8c85e8ca9ec8",
+                "sha256:a761b60da0ecaf6a9866985bcde26327883ac3cdb90535ab68b8d784f02b05ef",
+                "sha256:a84da9fa891848e0270e8e04dcca073bc9046441eeb47069f5c0e36783debbea",
+                "sha256:b8816c6410fa08d2a022e4e38d128bae97c1855e176a00493d6ec62ccd606d57",
+                "sha256:dfc32db6ce9ecc35a131320888b547199f79822b028934bb5b332f4169393e15",
+                "sha256:f65cba7924363e0d2f416041b48ff69d559548f2cb168ff972c54e09e1e64db8",
+                "sha256:fd7ddab7d6afee4e21c03c648c8b667b197104713e57ec404d5b74097af21e31"
             ],
             "index": "pypi",
-            "version": "==2.9.1"
+            "version": "==2.9.2"
         },
         "psycopg2-binary": {
             "hashes": [
-                "sha256:0b7dae87f0b729922e06f85f667de7bf16455d411971b2043bbd9577af9d1975",
-                "sha256:0f2e04bd2a2ab54fa44ee67fe2d002bb90cee1c0f1cc0ebc3148af7b02034cbd",
-                "sha256:123c3fb684e9abfc47218d3784c7b4c47c8587951ea4dd5bc38b6636ac57f616",
-                "sha256:1473c0215b0613dd938db54a653f68251a45a78b05f6fc21af4326f40e8360a2",
-                "sha256:14db1752acdd2187d99cb2ca0a1a6dfe57fc65c3281e0f20e597aac8d2a5bd90",
-                "sha256:1e3a362790edc0a365385b1ac4cc0acc429a0c0d662d829a50b6ce743ae61b5a",
-                "sha256:1e85b74cbbb3056e3656f1cc4781294df03383127a8114cbc6531e8b8367bf1e",
-                "sha256:1f6ca4a9068f5c5c57e744b4baa79f40e83e3746875cac3c45467b16326bab45",
-                "sha256:20f1ab44d8c352074e2d7ca67dc00843067788791be373e67a0911998787ce7d",
-                "sha256:24b0b6688b9f31a911f2361fe818492650795c9e5d3a1bc647acbd7440142a4f",
-                "sha256:2f62c207d1740b0bde5c4e949f857b044818f734a3d57f1d0d0edc65050532ed",
-                "sha256:3242b9619de955ab44581a03a64bdd7d5e470cc4183e8fcadd85ab9d3756ce7a",
-                "sha256:35c4310f8febe41f442d3c65066ca93cccefd75013df3d8c736c5b93ec288140",
-                "sha256:4235f9d5ddcab0b8dbd723dca56ea2922b485ea00e1dafacf33b0c7e840b3d32",
-                "sha256:542875f62bc56e91c6eac05a0deadeae20e1730be4c6334d8f04c944fcd99759",
-                "sha256:5ced67f1e34e1a450cdb48eb53ca73b60aa0af21c46b9b35ac3e581cf9f00e31",
-                "sha256:661509f51531ec125e52357a489ea3806640d0ca37d9dada461ffc69ee1e7b6e",
-                "sha256:7360647ea04db2e7dff1648d1da825c8cf68dc5fbd80b8fb5b3ee9f068dcd21a",
-                "sha256:736b8797b58febabb85494142c627bd182b50d2a7ec65322983e71065ad3034c",
-                "sha256:8c13d72ed6af7fd2c8acbd95661cf9477f94e381fce0792c04981a8283b52917",
-                "sha256:988b47ac70d204aed01589ed342303da7c4d84b56c2f4c4b8b00deda123372bf",
-                "sha256:995fc41ebda5a7a663a254a1dcac52638c3e847f48307b5416ee373da15075d7",
-                "sha256:a36c7eb6152ba5467fb264d73844877be8b0847874d4822b7cf2d3c0cb8cdcb0",
-                "sha256:aed4a9a7e3221b3e252c39d0bf794c438dc5453bc2963e8befe9d4cd324dff72",
-                "sha256:aef9aee84ec78af51107181d02fe8773b100b01c5dfde351184ad9223eab3698",
-                "sha256:b0221ca5a9837e040ebf61f48899926b5783668b7807419e4adae8175a31f773",
-                "sha256:b4d7679a08fea64573c969f6994a2631908bb2c0e69a7235648642f3d2e39a68",
-                "sha256:c250a7ec489b652c892e4f0a5d122cc14c3780f9f643e1a326754aedf82d9a76",
-                "sha256:ca86db5b561b894f9e5f115d6a159fff2a2570a652e07889d8a383b5fae66eb4",
-                "sha256:cfc523edecddaef56f6740d7de1ce24a2fdf94fd5e704091856a201872e37f9f",
-                "sha256:d92272c7c16e105788efe2cfa5d680f07e34e0c29b03c1908f8636f55d5f915a",
-                "sha256:da113b70f6ec40e7d81b43d1b139b9db6a05727ab8be1ee559f3a69854a69d34",
-                "sha256:ebccf1123e7ef66efc615a68295bf6fdba875a75d5bba10a05073202598085fc",
-                "sha256:f6fac64a38f6768e7bc7b035b9e10d8a538a9fadce06b983fb3e6fa55ac5f5ce",
-                "sha256:f8559617b1fcf59a9aedba2c9838b5b6aa211ffedecabca412b92a1ff75aac1a",
-                "sha256:fbb42a541b1093385a2d8c7eec94d26d30437d0e77c1d25dae1dcc46741a385e"
+                "sha256:029e09a892b9ebc3c77851f69ce0720e1b72a9c6850460cee49b14dfbf9ccdd2",
+                "sha256:108b0380969ddab7c8ef2a813a57f87b308b2f88ec15f1a1e7b653964a3cfb25",
+                "sha256:14427437117f38e65f71db65d8eafd0e86837be456567798712b8da89db2b2dd",
+                "sha256:234b1f48488b2f86aac04fb00cb04e5e9bcb960f34fa8a8e41b73149d581a93b",
+                "sha256:2e4bbcfb403221ea1953f3e0a85cef00ed15c1683a66cf35c956a7e37c33a4c4",
+                "sha256:2eecbdc5fa5886f2dd6cc673ce4291cc0fb8900965315268960ad9c2477f8276",
+                "sha256:37c8f00f7a2860bac9f7a54f03c243fc1dd9b367e5b2b52f5a02e5f4e9d8c49b",
+                "sha256:3865d0cd919349c45603bd7e80249a382c5ecf8106304cfd153282adf9684b6a",
+                "sha256:3a320e7a804f3886a599fea507364aaafbb8387027fffcdfbd34d96316c806c7",
+                "sha256:3ac83656ff4fbe7f2a956ab085e3eb1d678df54759965d509bdd6a06ce520d49",
+                "sha256:497372cc76e6cbce2f51b37be141f360a321423c03eb9be45524b1d123f4cd11",
+                "sha256:4c2dea4deac3dd3687e32daeb0712ee96c535970dfdded37a11de6a21145ab0e",
+                "sha256:53912199abb626a7249c662e72b70b4f57bf37f840599cec68625171435790dd",
+                "sha256:5671699aff57d22a245b7f4bba89e3de97dc841c5e98bd7f685429b2b20eca47",
+                "sha256:578c279cd1ce04f05ae0912530ece00bab92854911808e5aec27588aba87e361",
+                "sha256:717525cdc97b23182ff6f470fb5bf6f0bc796b5a7000c6f6699d6679991e4a5e",
+                "sha256:7585ca73dcfe326f31fafa8f96e6bb98ea9e9e46c7a1924ec8101d797914ae27",
+                "sha256:7e6bd4f532c2cd297b81114526176b240109a1c52020adca69c3f3226c65dc18",
+                "sha256:8d2aafe46eb87742425ece38130510fbb035787ee89a329af299029c4d9ae318",
+                "sha256:9c0aaad07941419926b9bd00171e49fe6b06e42e5527fb91671e137fe6c93d77",
+                "sha256:a04cfa231e7d9b63639e62166a4051cb47ca599fa341463fa3e1c48585fcee64",
+                "sha256:a1852c5bef7e5f52bd43fde5eda610d4df0fb2efc31028150933e84b4140d47a",
+                "sha256:a507db7758953b1b170c4310691a1a89877029b1e11b08ba5fc8ae3ddb35596b",
+                "sha256:a77e98c68b0e6c51d4d6a994d22b30e77276cbd33e4aabdde03b9ad3a2c148aa",
+                "sha256:aa2847d8073951dbc84c4f8b32c620764db3c2eb0d99a04835fecfab7d04816e",
+                "sha256:b592f09ff18cfcc9037b9a976fcd62db48cae9dbd5385f2471d4c2ba40c52b4d",
+                "sha256:b9d45374ba98c1184df9cce93a0b766097544f8bdfcd5de83ff10f939c193125",
+                "sha256:bf31e6fdb4ec1f6d98a07f48836508ed6edd19b48b13bbf168fbc1bd014b4ca2",
+                "sha256:c0e1fb7097ded2cc44d9037cfc68ad86a30341261492e7de95d180e534969fb2",
+                "sha256:c6e16e085fe6dc6c099ee0be56657aa9ad71027465ef9591d302ba230c404c7e",
+                "sha256:daf6b5c62eb738872d61a1fa740d7768904911ba5a7e055ed72169d379b58beb",
+                "sha256:db1b03c189f85b8df29030ad32d521dd7dcb862fd5f8892035314f5b886e70ce",
+                "sha256:eeee7b18c51d02e49bf1984d7af26e8843fe68e31fa1cbab5366ebdfa1c89ade",
+                "sha256:ef97578fab5115e3af4334dd3376dea3c3a79328a3314b21ec7ced02920b916d",
+                "sha256:f4dff0f15af6936c6fe6da7067b4216edbbe076ad8625da819cc066591b1133c",
+                "sha256:f9c37ecb173d76cf49e519133fd70851b8f9c38b6b8c1cb7fcfc71368d4cc6fc"
             ],
             "index": "pypi",
-            "version": "==2.9.1"
+            "version": "==2.9.2"
+        },
+        "pyjwt": {
+            "hashes": [
+                "sha256:b888b4d56f06f6dcd777210c334e69c737be74755d3e5e9ee3fe67dc18a0ee41",
+                "sha256:e0c4bb8d9f0af0c7f5b1ec4c5036309617d03d56932877f2f7a0beeb5318322f"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.3.0"
         },
         "pyrsistent": {
             "hashes": [
@@ -330,11 +346,11 @@
         },
         "python-dotenv": {
             "hashes": [
-                "sha256:14f8185cc8d494662683e6914addcb7e95374771e707601dfc70166946b4c4b8",
-                "sha256:bbd3da593fc49c249397cbfbcc449cf36cb02e75afc8157fcc6a81df6fb7750a"
+                "sha256:32b2bdc1873fd3a3c346da1c6db83d0053c3c62f28f1f38516070c4c8971b1d3",
+                "sha256:a5de49a31e953b45ff2d2fd434bbc2670e8db5273606c1e737cc6b93eff3655f"
             ],
             "index": "pypi",
-            "version": "==0.19.1"
+            "version": "==0.19.2"
         },
         "pyyaml": {
             "hashes": [
@@ -385,52 +401,52 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:07ac4461a1116b317519ddf6f34bcb00b011b5c1370ebeaaf56595504ffc7e84",
-                "sha256:090536fd23bf49077ee94ff97142bc5ee8bad24294c3d7c8d5284267c885dde7",
-                "sha256:1dee515578d04bc80c4f9a8c8cfe93f455db725059e885f1b1da174d91c4d077",
-                "sha256:1ef37c9ec2015ce2f0dc1084514e197f2f199d3dc3514190db7620b78e6004c8",
-                "sha256:295b90efef1278f27fe27d94a45460ae3c17f5c5c2b32c163e29c359740a1599",
-                "sha256:2ce42ad1f59eb85c55c44fb505f8854081ee23748f76b62a7f569cfa9b6d0604",
-                "sha256:2feb028dc75e13ba93456a42ac042b255bf94dbd692bf80b47b22653bb25ccf8",
-                "sha256:31f4426cfad19b5a50d07153146b2bcb372a279975d5fa39f98883c0ef0f3313",
-                "sha256:3c0c5f54560a92691d54b0768d67b4d3159e514b426cfcb1258af8c195577e8f",
-                "sha256:463ef692259ff8189be42223e433542347ae17e33f91c1013e9c5c64e2798088",
-                "sha256:4a882dedb9dfa6f33524953c3e3d72bcf518a5defd6d5863150a821928b19ad3",
-                "sha256:4c185c928e2638af9bae13acc3f70e0096eac76471a1101a10f96b80666b8270",
-                "sha256:5039faa365e7522a8eb4736a54afd24a7e75dcc33b81ab2f0e6c456140f1ad64",
-                "sha256:5c6774b34782116ad9bdec61c2dbce9faaca4b166a0bc8e7b03c2b870b121d94",
-                "sha256:6bc7f9d7d90ef55e8c6db1308a8619cd8f40e24a34f759119b95e7284dca351a",
-                "sha256:7e8ef103eaa72a857746fd57dda5b8b5961e8e82a528a3f8b7e2884d8506f0b7",
-                "sha256:7ef421c3887b39c6f352e5022a53ac18de8387de331130481cb956b2d029cad6",
-                "sha256:908fad32c53b17aad12d722379150c3c5317c422437e44032256a77df1746292",
-                "sha256:91efbda4e6d311812f23996242bad7665c1392209554f8a31ec6db757456db5c",
-                "sha256:a6506c17b0b6016656783232d0bdd03fd333f1f654d51a14d93223f953903646",
-                "sha256:a95bf9c725012dcd7ea3cac16bf647054e0d62b31d67467d228338e6a163e4ff",
-                "sha256:ad7e403fc1e3cb76e802872694e30d6ca6129b9bc6ad4e7caa48ca35f8a144f8",
-                "sha256:b86f762cee3709722ab4691981958cbec475ea43406a6916a7ec375db9cbd9e9",
-                "sha256:ba84026e84379326bbf2f0c50792f2ae56ab9c01937df5597b6893810b8ca369",
-                "sha256:bca660b76672e15d70a7dba5e703e1ce451a0257b6bd2028e62b0487885e8ae9",
-                "sha256:c24c01dcd03426a5fe5ee7af735906bec6084977b9027a3605d11d949a565c01",
-                "sha256:c2f2114b0968a280f94deeeaa31cfbac9175e6ac7bd3058b3ce6e054ecd762b3",
-                "sha256:c46f013ff31b80cbe36410281675e1fb4eaf3e25c284fd8a69981c73f6fa4cb4",
-                "sha256:c757ba1279b85b3460e72e8b92239dae6f8b060a75fb24b3d9be984dd78cfa55",
-                "sha256:cc6b21f19bc9d4cd77cbcba5f3b260436ce033f1053cea225b6efea2603d201e",
-                "sha256:dbf588ab09e522ac2cbd010919a592c6aae2f15ccc3cd9a96d01c42fbc13f63e",
-                "sha256:de996756d894a2d52c132742e3b6d64ecd37e0919ddadf4dc3981818777c7e67",
-                "sha256:e700d48056475d077f867e6a36e58546de71bdb6fdc3d34b879e3240827fefab",
-                "sha256:f1e97c5f36b94542f72917b62f3a2f92be914b2cf33b80fa69cede7529241d2a",
-                "sha256:fb2aa74a6e3c2cebea38dd21633671841fbe70ea486053cba33d68e3e22ccc0a",
-                "sha256:ff8f91a7b1c4a1c7772caa9efe640f2768828897044748f2458b708f1026e2d4"
+                "sha256:015511c52c650eebf1059ed8a21674d9d4ae567ebfd80fc73f8252faccd71864",
+                "sha256:0438bccc16349db2d5203598be6073175ce16d4e53b592d6e6cef880c197333e",
+                "sha256:10230364479429437f1b819a8839f1edc5744c018bfeb8d01320930f97695bc9",
+                "sha256:2146ef996181e3d4dd20eaf1d7325eb62d6c8aa4dc1677c1872ddfa8561a47d9",
+                "sha256:24828c5e74882cf41516740c0b150702bee4c6817d87d5c3d3bafef2e6896f80",
+                "sha256:2717ceae35e71de1f58b0d1ee7e773d3aab5c403c6e79e8d262277c7f7f95269",
+                "sha256:2e93624d186ea7a738ada47314701c8830e0e4b021a6bce7fbe6f39b87ee1516",
+                "sha256:435b1980c1333ffe3ab386ad28d7b209590b0fa83ea8544d853e7a22f957331b",
+                "sha256:486f7916ef77213103467924ef25f5ea1055ae901f385fe4d707604095fdf6a9",
+                "sha256:4ac8306e04275d382d6393e557047b0a9d7ddf9f7ca5da9b3edbd9323ea75bd9",
+                "sha256:4d1d707b752137e6bf45720648e1b828d5e4881d690df79cca07f7217ea06365",
+                "sha256:52f23a76544ed29573c0f3ee41f0ca1aedbab3a453102b60b540cc6fa55448ad",
+                "sha256:5beeff18b4e894f6cb73c8daf2c0d8768844ef40d97032bb187d75b1ec8de24b",
+                "sha256:6510f4a5029643301bdfe56b61e806093af2101d347d485c42a5535847d2c699",
+                "sha256:6afa9e4e63f066e0fd90a21db7e95e988d96127f52bfb298a0e9bec6999357a9",
+                "sha256:771eca9872b47a629010665ff92de1c248a6979b8d1603daced37773d6f6e365",
+                "sha256:78943451ab3ffd0e27876f9cea2b883317518b418f06b90dadf19394534637e9",
+                "sha256:8327e468b1775c0dfabc3d01f39f440585bf4d398508fcbbe2f0d931c502337d",
+                "sha256:8dbe5f639e6d035778ebf700be6d573f82a13662c3c2c3aa0f1dba303b942806",
+                "sha256:9134e5810262203388b203c2022bbcbf1a22e89861eef9340e772a73dd9076fa",
+                "sha256:9369f927f4d19b58322cfea8a51710a3f7c47a0e7f3398d94a4632760ecd74f6",
+                "sha256:987fe2f84ceaf744fa0e48805152abe485a9d7002c9923b18a4b2529c7bff218",
+                "sha256:a5881644fc51af7b232ab8d64f75c0f32295dfe88c2ee188023795cdbd4cf99b",
+                "sha256:a81e40dfa50ed3c472494adadba097640bfcf43db160ed783132045eb2093cb1",
+                "sha256:aadc6d1e58e14010ae4764d1ba1fd0928dbb9423b27a382ea3a1444f903f4084",
+                "sha256:ad8ec6b69d03e395db48df8991aa15fce3cd23e378b73e01d46a26a6efd5c26d",
+                "sha256:b02eee1577976acb4053f83d32b7826424f8b9f70809fa756529a52c6537eda4",
+                "sha256:bac949be7579fed824887eed6672f44b7c4318abbfb2004b2c6968818b535a2f",
+                "sha256:c035184af4e58e154b0977eea52131edd096e0754a88f7d5a847e7ccb3510772",
+                "sha256:c7d0a1b1258efff7d7f2e6cfa56df580d09ba29d35a1e3f604f867e1f685feb2",
+                "sha256:cc49fb8ff103900c20e4a9c53766c82a7ebbc183377fb357a8298bad216e9cdd",
+                "sha256:d768359daeb3a86644f3854c6659e4496a3e6bba2b4651ecc87ce7ad415b320c",
+                "sha256:d81c84c9d2523b3ea20f8e3aceea68615768a7464c0f9a9899600ce6592ec570",
+                "sha256:ec1c908fa721f2c5684900cc8ff75555b1a5a2ae4f5a5694eb0e37a5263cea44",
+                "sha256:fa52534076394af7315306a8701b726a6521b591d95e8f4e5121c82f94790e8d",
+                "sha256:fd421a14edf73cfe01e8f51ed8966294ee3b3db8da921cacc88e497fd6e977af"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.4.26"
+            "version": "==1.4.27"
         },
         "werkzeug": {
             "hashes": [
                 "sha256:63d3dc1cf60e7b7e35e97fa9861f7397283b75d765afcaefd993d6046899de8f",
                 "sha256:aa2bb6fc8dee8d6c504c0ac1e7f5f7dc5810a9903e793b6f715a9f015bdadb9a"
             ],
-            "markers": "python_version >= '3.6'",
+            "index": "pypi",
             "version": "==2.0.2"
         },
         "zipp": {

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ $ pipenv lock
 $ pip freeze > requirements.txt
 ```
 
-set up datatabase
+set up database
 
 ```
 $ cd app
@@ -90,7 +90,7 @@ $ python
 ```
 
 ```python shell
-> from app import db
+> from models import db
 
 # reset database
 > db.drop_all()

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ These additional packages need to be installed too. All of them are listed in th
 | SQLAlchemy       | 1.4.25                | Database Abstraction Library.                                                                           |
 | flasgger         | 0.9.5                 | Auto-API-Document Generator.                                                                            |
 | flask-swagger    | 0.2.14                | Extract swagger specs from your flask project.                                                          |
+| Flask-JWT-Extended         | 4.3.1                | JWT Authentication                                                                            |
+| Werkzeug    | 2.0.2                | A comprehensive WSGI web application library.                                                          |
 
 Create local postgres database named 'government'
 

--- a/app/app.py
+++ b/app/app.py
@@ -13,8 +13,8 @@ from app.feedback import *
 from app.assistant import *
 
 app.config["SWAGGER"] = {"title": "WCG-API", "universion": 1}
-# app.config['SECRET_KEY'] = os.getenv("SECRET_KEY")
-app.config['SECRET_KEY'] = "DUMMY_KEY_IS_NO_SECRET"
+app.config['SECRET_KEY'] = os.getenv("SECRET_KEY")
+# app.config['SECRET_KEY'] = "DUMMY_KEY_IS_NOT_A_SECRET"
 jwt = JWTManager(app)
 
 swagger_config = {

--- a/app/app.py
+++ b/app/app.py
@@ -1,16 +1,13 @@
 from flask import render_template, request, redirect, url_for, make_response, jsonify
-from flask_cors import cross_origin
-from string import Template
-from psycopg2.errors import UniqueViolation
+from flask_jwt_extended import create_access_token, get_jwt_identity, jwt_required, JWTManager
 from werkzeug.security import generate_password_hash, check_password_hash
-from datetime import datetime
-from flasgger import Swagger
+from psycopg2.errors import UniqueViolation
+from flask_cors import cross_origin
 from flasgger.utils import swag_from
+from flasgger import Swagger
+from datetime import datetime
+from string import Template
 import json, os
-from flask_jwt_extended import create_access_token
-from flask_jwt_extended import get_jwt_identity
-from flask_jwt_extended import jwt_required
-from flask_jwt_extended import JWTManager
 
 from app.feedback import *
 from app.assistant import *

--- a/app/app.py
+++ b/app/app.py
@@ -12,8 +12,8 @@ from flask_jwt_extended import get_jwt_identity
 from flask_jwt_extended import jwt_required
 from flask_jwt_extended import JWTManager
 
-from feedback import *
-from assistant import *
+from app.feedback import *
+from app.assistant import *
 
 app.config["SWAGGER"] = {"title": "WCG-API", "universion": 1}
 app.config['SECRET_KEY'] = os.getenv("SECRET_KEY")

--- a/app/app.py
+++ b/app/app.py
@@ -13,6 +13,8 @@ from app.feedback import *
 from app.assistant import *
 
 app.config["SWAGGER"] = {"title": "WCG-API", "universion": 1}
+# app.config['SECRET_KEY'] = os.getenv("SECRET_KEY")
+app.config['SECRET_KEY'] = "DUMMY_KEY_IS_NO_SECRET"
 jwt = JWTManager(app)
 
 swagger_config = {

--- a/app/app.py
+++ b/app/app.py
@@ -16,7 +16,6 @@ from app.feedback import *
 from app.assistant import *
 
 app.config["SWAGGER"] = {"title": "WCG-API", "universion": 1}
-app.config['SECRET_KEY'] = os.getenv("SECRET_KEY")
 jwt = JWTManager(app)
 
 swagger_config = {

--- a/app/app.py
+++ b/app/app.py
@@ -1,15 +1,23 @@
-from flask import render_template, request, redirect, url_for
+from flask import render_template, request, redirect, url_for, make_response, jsonify
 from flask_cors import cross_origin
 from string import Template
+from psycopg2.errors import UniqueViolation
+from werkzeug.security import generate_password_hash, check_password_hash
 from datetime import datetime
 from flasgger import Swagger
 from flasgger.utils import swag_from
-import json
+import json, os
+from flask_jwt_extended import create_access_token
+from flask_jwt_extended import get_jwt_identity
+from flask_jwt_extended import jwt_required
+from flask_jwt_extended import JWTManager
 
-from app.feedback import *
-from app.assistant import *
+from feedback import *
+from assistant import *
 
 app.config["SWAGGER"] = {"title": "WCG-API", "universion": 1}
+app.config['SECRET_KEY'] = os.getenv("SECRET_KEY")
+jwt = JWTManager(app)
 
 swagger_config = {
     "headers": [],
@@ -60,11 +68,16 @@ def citizen_get_by_citizen_id(citizen_id):
 
 @app.route('/registration', methods=['POST'])
 @cross_origin()
+@jwt_required()
 @swag_from("swagger/regispost.yml")
 def registration():
     """
     Accept and validate registration information.
     """
+    user = Users.query.filter_by(username=get_jwt_identity()).first()
+    if not user.has_privilege and not user.is_admin:
+        return {"feedback": AUTHENTICATION_FEEDBACK["unauthenticated"]}
+
     citizen_id = request.values['citizen_id']
     name = request.values['name']
     surname = request.values['surname']
@@ -93,6 +106,7 @@ def registration():
             logger.error(REGISTRATION_FEEDBACK["invalid_age"])
             return {"feedback": REGISTRATION_FEEDBACK["invalid_age"]}
     except ValueError:
+        
         logger.error(REGISTRATION_FEEDBACK["invalid_birthdate"])
         return {"feedback": REGISTRATION_FEEDBACK["invalid_birthdate"]}
 
@@ -120,11 +134,16 @@ def registration():
 
 @app.route('/registration', methods=['DELETE'])
 @cross_origin()
+@jwt_required()
 @swag_from("swagger/citizendel.yml")
 def reset_citizen_db():
     """
     Reset citizen database.
     """
+    user = Users.query.filter_by(username=get_jwt_identity()).first()
+    if not user.is_admin:
+        return {"feedback": AUTHENTICATION_FEEDBACK["unauthenticated"]}
+
     try:
         db.session.query(Citizen).delete()
         db.session.query(Reservation).delete()
@@ -139,11 +158,16 @@ def reset_citizen_db():
 
 @app.route('/registration/<citizen_id>', methods=['DELETE'])
 @cross_origin()
+@jwt_required()
 @swag_from("swagger/citizendel.yml")
 def delete_citizen_db(citizen_id):
     """
     Delete a citizen data.
     """
+    user = Users.query.filter_by(username=get_jwt_identity()).first()
+    if not user.is_admin:
+        return {"feedback": AUTHENTICATION_FEEDBACK["unauthenticated"]}
+
     if not is_citizen_id(citizen_id):
         logger.error(DELETE_FEEDBACK["invalid_id"])
         return redirect(url_for('citizen'), 404)
@@ -208,11 +232,16 @@ def get_reservation():
 
 @app.route('/reservation', methods=['POST'])
 @cross_origin()
+@jwt_required()
 @swag_from("swagger/reservepost.yml")
 def reservation():
     """
     Add reservation data to the database
     """
+    user = Users.query.filter_by(username=get_jwt_identity()).first()
+    if not user.has_privilege and not user.is_admin:
+        return {"feedback": AUTHENTICATION_FEEDBACK["unauthenticated"]}
+
     citizen_id = request.values['citizen_id']
     site_name = request.values['site_name']
     vaccine_name = request.values['vaccine_name']
@@ -263,11 +292,16 @@ def reservation():
 
 @app.route('/reservation/<citizen_id>', methods=['DELETE'])
 @cross_origin()
+@jwt_required()
 @swag_from("swagger/reservedel.yml")
 def cancel_reservation(citizen_id):
     """
     Cancel reservation and remove it from the database.
     """
+    user = Users.query.filter_by(username=get_jwt_identity()).first()
+    if not user.has_privilege and not user.is_admin:
+        return {"feedback": AUTHENTICATION_FEEDBACK["unauthenticated"]}
+
     if not (citizen_id):
         logger.error(CANCEL_RESERVATION_FEEDBACK["missing_key"])
         return {"feedback": CANCEL_RESERVATION_FEEDBACK["missing_key"]}
@@ -299,8 +333,13 @@ def cancel_reservation(citizen_id):
 
 @app.route('/queue_report', methods=['POST'])
 @cross_origin()
+@jwt_required()
 @swag_from("swagger/queuepost.yml")
 def update_queue():
+    user = Users.query.filter_by(username=get_jwt_identity()).first()
+    if not user.has_privilege and not user.is_admin:
+        return {"feedback": AUTHENTICATION_FEEDBACK["unauthenticated"]}
+
     citizen_id = request.values['citizen_id']
     queue = request.values['queue']
 
@@ -328,8 +367,13 @@ def update_queue():
 
 @app.route('/report_taken', methods=['POST'])
 @cross_origin()
+@jwt_required()
 @swag_from("swagger/reportpost.yml")
 def update_citizen_db():
+    user = Users.query.filter_by(username=get_jwt_identity()).first()
+    if not user.has_privilege and not user.is_admin:
+        return {"feedback": AUTHENTICATION_FEEDBACK["unauthenticated"]}
+
     citizen_id = request.values['citizen_id']
     vaccine_name = request.values['vaccine_name']
 
@@ -397,6 +441,46 @@ def update_citizen_db():
     logger.info("{} - updated citizen - vaccine name: {}".format(
         citizen_id, vaccine_name))
     return {"feedback": REPORT_FEEDBACK["success"]}
+
+@app.route('/register_user', methods=['POST'])
+@cross_origin()
+def register_user():
+    data = request.values
+    feedback = ""
+    try:
+        hashed_password = generate_password_hash(data['password'], method='sha256')
+        new_user = Users(username=data['username'], password=hashed_password, is_admin=False, has_privilege=True) 
+
+        db.session.add(new_user)
+        db.session.commit()
+        feedback = REGISTER_USER_FEEDBACK["successful_registration"]
+        return json.dumps(feedback, ensure_ascii=False), 201
+    except Exception as e:
+        if isinstance(e.orig, UniqueViolation):
+            feedback = REGISTER_USER_FEEDBACK["duplicated_registration"]
+        else:
+            feedback = REGISTER_USER_FEEDBACK["failed_registration"]
+        db.session.rollback()
+        logger.error(feedback)
+        return {"feedback": feedback}
+
+
+@app.route('/login', methods=['POST'])  
+def login_user(): 
+    print("ffp")
+    auth = request.authorization 
+    print("bar")  
+
+    if not auth or not auth.username or not auth.password:  
+        return make_response('could not verify', 401, {'WWW.Authentication': 'Basic realm: "login required"'})    
+
+    user = Users.query.filter_by(username=auth.username).first()   
+        
+    if check_password_hash(user.password, auth.password):  
+        access_token = create_access_token(identity=auth.username)
+        return jsonify(access_token=access_token)
+
+    return make_response('could not verify',  401, {'WWW.Authentication': 'Basic realm: "login required"'})
 
 
 @app.route('/')

--- a/app/assistant.py
+++ b/app/assistant.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from models import *
+from app.models import *
 
 VACCINE_SEQUENCE = [
     ["Pfizer", "Pfizer"],

--- a/app/assistant.py
+++ b/app/assistant.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from app.models import *
+from models import *
 
 VACCINE_SEQUENCE = [
     ["Pfizer", "Pfizer"],

--- a/app/feedback.py
+++ b/app/feedback.py
@@ -49,3 +49,17 @@ DELETE_FEEDBACK = {
     'invalid_id':           'delete failed: invalid citizen ID',
     'not_registered':       'delete failed: citizen ID is not registered'
 }
+
+REGISTER_USER_FEEDBACK = {
+    "successful_registration" : "new user created successfully",
+    "failed_registration" : "registration failed: unable to register a new user",
+    "duplicated_registration" : "registration failed: user already exists"
+}
+
+# LOGIN_FEEDBACK = {
+
+# }
+
+AUTHENTICATION_FEEDBACK = {
+    "unauthenticated" : "no permissions allowed for this user"
+}

--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,7 @@
 from flask import Flask
 from flask_cors import CORS
 from flask_sqlalchemy import SQLAlchemy
+from werkzeug.security import generate_password_hash, check_password_hash
 from datetime import datetime
 import os
 import logging
@@ -126,3 +127,22 @@ class Reservation(db.Model):
             "queue": str(self.queue),
             "checked": str(self.checked)
         }
+
+
+class Users(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(200), unique=True)
+    password = db.Column(db.String(200))
+    is_admin = db.Column(db.Boolean)
+    has_privilege = db.Column(db.Boolean) # need to change variable name later
+
+    # def __init__(self, username, password, is_admin=False, has_privilege=True):
+    #     self.username = username
+    #     hashed_password = generate_password_hash(password, method='sha256')
+    #     self.password = hashed_password
+    #     self.is_admin = is_admin
+    #     self.has_privilege = has_privilege
+
+    #     logger.info(
+    #     'created authenticated user: {} - is-admin: {} - has-privilege: {}'
+    #     .format(self.username, self.is_admin, self.has_privilege))

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ psycopg2==2.9.1
 psycopg2-binary==2.9.1
 python-dotenv==0.19.1
 SQLAlchemy==1.4.26
+Flask-JWT-Extended==4.3.1
+Werkzeug==2.0.2


### PR DESCRIPTION
I have added the **jwt** authentication and the models are updated.

The models have to somehow be migrated, but migrating in flask is tricky.
I need help with deployment.

Just need two people to approve this, and then we can merge this branch to master.

## Feature/Usage

### Register User:
**POST** method
```
https://wcg-apis-test.herokuapp.com/register_user?username=<your_username>&password=<your_password>
```

### Login:
**POST** method (maybe I should allow GET too)
```
https://wcg-apis-test.herokuapp.com/login
```
Use the postman to invoke the method with authentication (see screenshot).
![image](https://user-images.githubusercontent.com/59855413/143389901-ed39bb9b-27ab-42d8-bb6f-6dd6ea79914c.png)

A bearer token will be returned.
![image](https://user-images.githubusercontent.com/59855413/143392075-78461c3d-abcf-453c-a9d2-03934cc85f8e.png)

### Token Usage Example
**POST** method
```
https://wcg-apis-test.herokuapp.com/registration?citizen_id=<citizen_id>&name=<name>&surname=<surname>&birth_date=<birth_date>&occupation=<occupation>&address=<address>&phone_number=<phone_number>&is_risk=<true_or_false>
```
![image](https://user-images.githubusercontent.com/59855413/143405740-647a119f-0820-440b-b796-58bffef4706f.png)


### Caveats:
Right now, you cannot reset the database via API usage unless there is a way to manually set permissions.
